### PR TITLE
feat: show active GPU processes (name + PID)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Dashboard web con metricas en tiempo real accesible en `/`. Muestra cards con te
 | Metodo | Ruta          | Descripcion                              |
 |--------|---------------|------------------------------------------|
 | GET    | `/`           | Dashboard web con metricas en tiempo real |
-| GET    | `/api/health` | Healthcheck                               |
-| GET    | `/api/gpu`    | Temperatura y fan speed de la GPU (JSON)  |
+| GET    | `/api/health`         | Healthcheck                               |
+| GET    | `/api/gpu`            | Temperatura y fan speed de la GPU (JSON)  |
+| GET    | `/api/gpu/processes`  | Procesos activos en la GPU (PID y nombre) |
 
-## Ejemplo de respuesta
+## Ejemplos de respuesta
 
 ```bash
 curl http://localhost:8001/api/gpu
@@ -52,6 +53,22 @@ curl http://localhost:8001/api/gpu
 {
   "temperature_c": 45,
   "fan_speed_percent": 30
+}
+```
+
+```bash
+curl http://localhost:8001/api/gpu/processes
+```
+
+```json
+{
+  "processes": [
+    {
+      "pid": 1234,
+      "name": "/usr/bin/python3",
+      "used_gpu_memory_bytes": 524288000
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
## Summary

- Nuevo endpoint `GET /api/gpu/processes` que lista los procesos usando activamente la GPU
- Devuelve PID, nombre del proceso y memoria GPU consumida por cada proceso

## Cambios

- Importar `nvmlDeviceGetComputeRunningProcesses`, `nvmlDeviceGetGraphicsRunningProcesses`, `nvmlSystemGetProcessName` de pynvml
- Nuevo endpoint que combina procesos de compute y graphics, deduplica por PID, y resuelve el nombre del proceso

## Ejemplo de respuesta

```bash
curl http://localhost:8001/api/gpu/processes
```

```json
{
  "processes": [
    {
      "pid": 1234,
      "name": "/usr/bin/python3",
      "used_gpu_memory_bytes": 524288000
    },
    {
      "pid": 5678,
      "name": "C:\Windows\System32\dwm.exe",
      "used_gpu_memory_bytes": 104857600
    }
  ]
}
```

## Test plan

- [x] Verificar que `GET /api/gpu/processes` devuelve lista de procesos con PID y nombre
- [x] Verificar respuesta con GPU sin procesos activos: `{"processes": []}`
- [x] Verificar que no hay duplicados cuando un proceso aparece en compute y graphics
- [x] Verificar que procesos con nombre no resolvible aparecen como `"unknown"`
- [x] Verificar que los endpoints existentes (`/api/health`, `/api/gpu`) no se ven afectados

🤖 Generated with [Claude Code](https://claude.com/claude-code)