### PR TITLE
fix: GPU processes not visible from container

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ curl http://localhost:8001/api/gpu/processes
 }
 ```
 
+## Notas
+
+El container usa `pid: host` en docker-compose para compartir el PID namespace del host. Esto permite que NVML vea todos los procesos del sistema que usan la GPU (no solo los del container).
+
 ## Licencia
 
 MIT

--- a/app/main.py
+++ b/app/main.py
@@ -74,7 +74,7 @@ def gpu_processes():
             seen[proc.pid] = {
                 "pid": proc.pid,
                 "name": name,
-                "used_gpu_memory_bytes": proc.usedGpuMemory,
+                "used_gpu_memory_bytes": proc.usedGpuMemory or 0,
             }
 
         return {"processes": list(seen.values())}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
     build: .
     ports:
       - "8001:8001"
+    pid: host
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary

- Agrega `pid: host` a docker-compose.yml para compartir el PID namespace del host
- Corrige `used_gpu_memory_bytes: null` defaulteando a 0

Closes #7

## Cambios

- **docker-compose.yml**: agrega `pid: host` para que NVML vea procesos del host
- **app/main.py**: `proc.usedGpuMemory or 0` para evitar null en la respuesta
- **README.md**: agrega nota sobre `pid: host`

## Test plan

- [ ] Rebuild: `docker compose up --build`
- [ ] `curl /api/gpu/processes` lista procesos del host (DWM, browsers, etc.)
- [ ] PIDs coinciden con `nvidia-smi`
- [ ] `used_gpu_memory_bytes` tiene valores numericos (no null)

🤖 Generated with [Claude Code](https://claude.com/claude-code)