### PR TITLE
fix: use nvidia-smi to list all GPU processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ curl http://localhost:8001/api/gpu/processes
 }
 ```
 
+## Notas
+
+El endpoint `/api/gpu/processes` usa `nvidia-smi` para listar procesos GPU del host. Esto resuelve la limitacion de la API NVML de Python que dentro de Docker Desktop (WSL2) solo ve procesos del container.
+
 ## Licencia
 
 MIT

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -9,9 +10,6 @@ from pynvml import (
     nvmlDeviceGetHandleByIndex,
     nvmlDeviceGetTemperature,
     nvmlDeviceGetFanSpeed,
-    nvmlDeviceGetComputeRunningProcesses,
-    nvmlDeviceGetGraphicsRunningProcesses,
-    nvmlSystemGetProcessName,
     NVML_TEMPERATURE_GPU,
     NVMLError,
 )
@@ -59,24 +57,49 @@ def gpu_metrics():
 @app.get("/api/gpu/processes")
 def gpu_processes():
     try:
-        handle = nvmlDeviceGetHandleByIndex(0)
-        compute = nvmlDeviceGetComputeRunningProcesses(handle)
-        graphics = nvmlDeviceGetGraphicsRunningProcesses(handle)
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-compute-apps=pid,process_name,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        compute_lines = result.stdout.strip().splitlines() if result.stdout.strip() else []
+
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-graphics-apps=pid,process_name,used_gpu_memory",
+                "--format=csv,noheader,nounits",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        graphics_lines = result.stdout.strip().splitlines() if result.stdout.strip() else []
 
         seen = {}
-        for proc in compute + graphics:
-            if proc.pid in seen:
+        for line in compute_lines + graphics_lines:
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) < 3:
                 continue
+            pid = int(parts[0])
+            if pid in seen:
+                continue
+            name = parts[1] if parts[1] != "[N/A]" else "unknown"
             try:
-                name = nvmlSystemGetProcessName(proc.pid)
-            except NVMLError:
-                name = "unknown"
-            seen[proc.pid] = {
-                "pid": proc.pid,
+                mem = int(parts[2]) * 1024 * 1024
+            except (ValueError, TypeError):
+                mem = 0
+            seen[pid] = {
+                "pid": pid,
                 "name": name,
-                "used_gpu_memory_bytes": proc.usedGpuMemory,
+                "used_gpu_memory_bytes": mem,
             }
 
         return {"processes": list(seen.values())}
-    except NVMLError as e:
+    except Exception as e:
         return {"error": str(e)}


### PR DESCRIPTION
## Summary

Reemplaza las llamadas NVML de Python por parsing de `nvidia-smi` para listar procesos GPU. La API NVML (`nvmlDeviceGetComputeRunningProcesses` / `nvmlDeviceGetGraphicsRunningProcesses`) solo ve procesos dentro del PID namespace del container, mientras que `nvidia-smi` consulta el driver directamente y lista procesos del host Windows.

Closes #7
Supersedes #8

## Problema original

```json
{"processes":[{"pid":28,"name":"/Xwayland","used_gpu_memory_bytes":null}]}
```

Solo mostraba procesos internos del container (Xwayland). Faltaban procesos del host (DWM, browsers, juegos, CUDA workloads).

## Enfoque anterior (PR #8 - cerrado)

`pid: host` en docker-compose.yml no funciona en Docker Desktop/WSL2 porque comparte el PID namespace de la VM Linux, no el de Windows.

## Nuevo enfoque

- Usa `nvidia-smi --query-compute-apps` y `--query-graphics-apps` con formato CSV
- Parsea PID, nombre del proceso y memoria GPU usada
- Deduplica por PID (un proceso puede aparecer en compute y graphics)
- Convierte memoria de MiB (nvidia-smi) a bytes
- Maneja `[N/A]` como "unknown"

## Test plan

- [ ] `docker compose up --build`
- [ ] `curl http://localhost:8001/api/gpu/processes` lista procesos del host Windows
- [ ] PIDs y nombres coinciden con lo que muestra `nvidia-smi` en el host
- [ ] `used_gpu_memory_bytes` tiene valores numericos
- [ ] Endpoints existentes (`/api/health`, `/api/gpu`, `/`) no afectados

🤖 Generated with [Claude Code](https://claude.com/claude-code)